### PR TITLE
Implement delegate for circumventing the WPF embedded font resource m…

### DIFF
--- a/LiteHtmlSharp.Wpf/FontInfo.cs
+++ b/LiteHtmlSharp.Wpf/FontInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Windows.Media;
@@ -20,11 +20,13 @@ namespace LiteHtmlSharp.Wpf
 
       public TextDecorationCollection Decorations = new TextDecorationCollection();
 
-      public FontInfo(string faceName, FontStyle style, FontWeight weight, int size)
+      public FontInfo(string faceName, FontStyle style, FontWeight weight, int size, FontFamily fontFamily = null)
       {
-         // Using the pack URI means we can look inside resources in addition to system fonts.
+         // Using the pack URI means we can look inside resources in addition to system fonts - this is only supported for backwards compatibility, as it causes memory leaks.
+         // https://stackoverflow.com/questions/31452443/wpf-textblock-memory-leak-when-using-font
          // FontFamily will allow comma separated font names, but does not support quotes of any kind (so don't quote it in your HTML/CSS!).
-         Family = new FontFamily(new Uri("pack://application:,,,/Fonts/"), faceName);
+
+         Family = fontFamily ?? new FontFamily(new Uri("pack://application:,,,/Fonts/"), faceName);
 
          TypeFace = new Typeface(Family, style, weight, new FontStretch());
          Size = size;

--- a/LiteHtmlSharp.Wpf/WPFContainer.cs
+++ b/LiteHtmlSharp.Wpf/WPFContainer.cs
@@ -39,9 +39,13 @@ namespace LiteHtmlSharp.Wpf
       }
    }
 
+   public delegate FontFamily FontAbsolutePathDelegate(string fontName);
+    
    public class WpfContainer : ViewportContainer
    {
       IResourceLoader _loader;
+
+      public FontAbsolutePathDelegate FontAbsolutePathDelegate;
 
       class ResourceLoader : IResourceLoader
       {
@@ -282,8 +286,9 @@ namespace LiteHtmlSharp.Wpf
 
       protected override UIntPtr CreateFont(string faceName, int size, int weight, font_style italic, font_decoration decoration, ref font_metrics fm)
       {
-         var fontweight = FontWeight.FromOpenTypeWeight(weight);
-         FontInfo font = new FontInfo(faceName, italic == font_style.fontStyleItalic ? FontStyles.Italic : FontStyles.Normal, fontweight, size);
+         var fontweight = FontWeight.FromOpenTypeWeight(weight);    
+         FontInfo font = new FontInfo(family, italic == font_style.fontStyleItalic ? FontStyles.Italic : FontStyles.Normal, fontweight, size, FontAbsolutePathDelegate?.Invoke(family));
+
          if ((decoration & font_decoration.font_decoration_underline) != 0)
          {
             font.Decorations.Add(TextDecorations.Underline);


### PR DESCRIPTION
…emory leak (https://stackoverflow.com/questions/31452443/wpf-textblock-memory-leak-when-using-font)